### PR TITLE
Add bluebird as a direct dependency to resolve warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "base64-js": "^1.1.2",
+    "bluebird": "^3.5.1",
     "bluebird-retry": "^0.11.0",
     "es6-promise-pool": "^2.5.0",
     "jssha": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,10 @@ bluebird@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
+bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.7"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"


### PR DESCRIPTION
Installing percy-js as a dependency of another project currently results in a warning that peer dependency of bluebird is not met.  This PR resolves that warning by adding bluebird as an explicit dependency.