### PR TITLE
Read commit and branch information from local git commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "husky": "^0.14.3",
     "mocha": "^2.4.5",
     "nock": "^9.0.14",
-    "prettier": "^1.7.0"
+    "prettier": "^1.7.0",
+    "sinon": "^4.4.2"
   },
   "optionalDependencies": {
     "lint-staged": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "jssha": "^2.1.0",
     "regenerator-runtime": "^0.11.0",
     "request": "^2.40.0",
-    "request-promise": "^4.1.1",
-    "shelljs": "^0.8.1"
+    "request-promise": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jssha": "^2.1.0",
     "regenerator-runtime": "^0.11.0",
     "request": "^2.40.0",
-    "request-promise": "^4.1.1"
+    "request-promise": "^4.1.1",
+    "shelljs": "^0.8.1"
   }
 }

--- a/src/environment.js
+++ b/src/environment.js
@@ -37,13 +37,15 @@ class Environment {
     return null;
   }
 
-  gitExec(cmd) {
+  gitExec(args) {
     const child_process = require('child_process');
     try {
-      return child_process
-        .execSync(`git ${cmd}`)
-        .toString()
-        .trim();
+      let result = child_process.spawnSync('git', args);
+      if (result.status == 0) {
+        return result.stdout.toString().trim();
+      } else {
+        return '';
+      }
     } catch (error) {
       return '';
     }
@@ -55,8 +57,8 @@ class Environment {
       return '';
     }
 
-    const cmd = `show ${commitSha} --quiet --format="${GIT_COMMIT_FORMAT}"`;
-    return this.gitExec(cmd);
+    const args = ['show', commitSha, '--quiet', `--format="${GIT_COMMIT_FORMAT}"`];
+    return this.gitExec(args);
   }
 
   get commitData() {
@@ -176,7 +178,7 @@ class Environment {
   }
 
   rawBranch() {
-    return this.gitExec('rev-parse --abbrev-ref HEAD');
+    return this.gitExec(['rev-parse', '--abbrev-ref', 'HEAD']);
   }
 
   get targetBranch() {

--- a/src/environment.js
+++ b/src/environment.js
@@ -38,15 +38,23 @@ class Environment {
   }
 
   rawCommitData(commitSha) {
-    const shell = require('shelljs');
+    const child_process = require('child_process');
     const format = GIT_FORMAT_LINES.join('%n'); // git show format uses %n for newlines.
-    let result = shell.exec(`git show ${commitSha} --quiet --format="${format}"`, {silent: true});
 
-    if (result.code !== 0) {
+    // Make sure commitSha is only alphanumeric characters to prevent command injection.
+    if (commitSha.length > 100 || !commitSha.match(/^[0-9a-zA-Z]+$/)) {
       return '';
     }
 
-    return result.stdout.trim();
+    const cmd = `git show ${commitSha} --quiet --format="${format}"`;
+    try {
+      return child_process
+        .execSync(cmd)
+        .toString()
+        .trim();
+    } catch (error) {
+      return '';
+    }
   }
 
   get commitData() {
@@ -163,15 +171,16 @@ class Environment {
   }
 
   rawBranch() {
-    const shell = require('shelljs');
-    let result = shell.exec(`git rev-parse --abbrev-ref HEAD`, {silent: true});
-
-    if (result.code !== 0) {
-      shell.echo('Error: Git rev-parse failed');
+    const child_process = require('child_process');
+    const cmd = 'git rev-parse --abbrev-ref HEAD';
+    try {
+      return child_process
+        .execSync(cmd)
+        .toString()
+        .trim();
+    } catch (error) {
       return '';
     }
-
-    return result.stdout.trim();
   }
 
   get targetBranch() {

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,3 +1,14 @@
+const GIT_FORMAT_LINES = [
+  'COMMIT_SHA:%H',
+  'AUTHOR_NAME:%an',
+  'AUTHOR_EMAIL:%ae',
+  'COMMITTER_NAME:%an',
+  'COMMITTER_EMAIL:%ae',
+  'COMMITTED_DATE:%ai',
+  // Note: order is important, this must come last because the regex is a multiline match.
+  'COMMIT_MESSAGE:%B',
+];
+
 class Environment {
   constructor(env) {
     if (!env) {
@@ -24,6 +35,50 @@ class Environment {
       return 'buildkite';
     }
     return null;
+  }
+
+  rawCommitData(commitSha) {
+    const shell = require('shelljs');
+    const format = GIT_FORMAT_LINES.join('%n'); // git show format uses %n for newlines.
+    let result = shell.exec(`git show ${commitSha} --quiet --format="${format}"`, {silent: true});
+
+    if (result.code !== 0) {
+      return '';
+    }
+
+    return result.stdout.trim();
+  }
+
+  get commitData() {
+    let output = '';
+    if (this.commitSha) {
+      output = this.rawCommitData(this.commitSha);
+    }
+    if (!output || output == '') {
+      output = this.rawCommitData('HEAD');
+    }
+
+    // If not running in a git repo, allow nils for certain commit attributes.
+    const parse = regex => {
+      return ((output && output.match(regex)) || [])[1];
+    };
+
+    return {
+      // // The only required attribute:
+      branch: this.branch,
+      // // An optional but important attribute:
+      sha: this.commitSha || parse(/COMMIT_SHA:(.*)/),
+
+      // Optional attributes:
+      message: parse(/COMMIT_MESSAGE:(.*)/m),
+      committedAt: parse(/COMMITTED_DATE:(.*)/),
+      // These GIT_ environment vars are from the Jenkins Git Plugin, but could be
+      // used generically. This behavior may change in the future.
+      authorName: parse(/AUTHOR_NAME:(.*)/) || this._env['GIT_AUTHOR_NAME'],
+      authorEmail: parse(/AUTHOR_EMAIL:(.*)/) || this._env['GIT_AUTHOR_EMAIL'],
+      committerName: parse(/COMMITTER_NAME:(.*)/) || this._env['GIT_COMMITTER_NAME'],
+      committerEmail: parse(/COMMITTER_EMAIL:(.*)/) || this._env['GIT_COMMITTER_EMAIL'],
+    };
   }
 
   get commitSha() {
@@ -53,6 +108,7 @@ class Environment {
         return commitSha !== 'HEAD' ? this._env.BUILDKITE_COMMIT : null;
       }
     }
+
     return null;
   }
 
@@ -60,27 +116,56 @@ class Environment {
     if (this._env.PERCY_BRANCH) {
       return this._env.PERCY_BRANCH;
     }
+    let result = '';
     switch (this.ci) {
       case 'travis':
         if (this.pullRequestNumber && this._env.TRAVIS_PULL_REQUEST_BRANCH) {
-          return this._env.TRAVIS_PULL_REQUEST_BRANCH;
+          result = this._env.TRAVIS_PULL_REQUEST_BRANCH;
+        } else {
+          result = this._env.TRAVIS_BRANCH;
         }
-        return this._env.TRAVIS_BRANCH;
+        break;
       case 'jenkins':
-        return this._env.ghprbSourceBranch;
+        result = this._env.ghprbSourceBranch;
+        break;
       case 'circle':
-        return this._env.CIRCLE_BRANCH;
+        result = this._env.CIRCLE_BRANCH;
+        break;
       case 'codeship':
-        return this._env.CI_BRANCH;
+        result = this._env.CI_BRANCH;
+        break;
       case 'drone':
-        return this._env.DRONE_BRANCH;
+        result = this._env.DRONE_BRANCH;
+        break;
       case 'semaphore':
-        return this._env.BRANCH_NAME;
+        result = this._env.BRANCH_NAME;
+        break;
       case 'buildkite':
-        return this._env.BUILDKITE_BRANCH;
+        result = this._env.BUILDKITE_BRANCH;
+        break;
     }
+
+    if (result == '') {
+      result = this.rawBranch;
+    }
+    if (result == '') {
+      result = null;
+    }
+
     // Branch not specified
-    return null;
+    return result;
+  }
+
+  get rawBranch() {
+    const shell = require('shelljs');
+    let result = shell.exec(`git rev-parse --abbrev-ref HEAD`, {silent: true});
+
+    if (result.code !== 0) {
+      shell.echo('Error: Git rev-parse failed');
+      return '';
+    }
+
+    return result.stdout.trim();
   }
 
   get targetBranch() {

--- a/src/environment.js
+++ b/src/environment.js
@@ -58,6 +58,12 @@ class Environment {
       output = this.rawCommitData('HEAD');
     }
 
+    if (output == '') {
+      return {
+        branch: this.branch,
+      };
+    }
+
     // If not running in a git repo, allow nils for certain commit attributes.
     const parse = regex => {
       return ((output && output.match(regex)) || [])[1];
@@ -146,7 +152,7 @@ class Environment {
     }
 
     if (result == '') {
-      result = this.rawBranch;
+      result = this.rawBranch();
     }
     if (result == '') {
       result = null;
@@ -156,7 +162,7 @@ class Environment {
     return result;
   }
 
-  get rawBranch() {
+  rawBranch() {
     const shell = require('shelljs');
     let result = shell.exec(`git rev-parse --abbrev-ref HEAD`, {silent: true});
 

--- a/src/main.js
+++ b/src/main.js
@@ -130,13 +130,22 @@ class PercyClient {
     }
 
     options = options || {};
+
+    const commitData = options['commitData'] || this.environment.commitData;
+
     let data = {
       data: {
         type: 'builds',
         attributes: {
-          branch: this.environment.branch,
+          branch: commitData.branch,
           'target-branch': this.environment.targetBranch,
-          'commit-sha': this.environment.commitSha,
+          'commit-sha': commitData.sha,
+          'commit-committed-at': commitData.committedAt,
+          'commit-author-name': commitData.authorName,
+          'commit-author-email': commitData.authorEmail,
+          'commit-committer-name': commitData.committerName,
+          'commit-committer-email': commitData.committerEmail,
+          'commit-message': commitData.message,
           'pull-request-number': this.environment.pullRequestNumber,
           'parallel-nonce': parallelNonce,
           'parallel-total-shards': parallelTotalShards,

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -1,6 +1,7 @@
 let path = require('path');
 let Environment = require(path.join(__dirname, '..', 'src', 'environment'));
 let assert = require('assert');
+let sinon = require('sinon');
 
 describe('Environment', function() {
   let environment;
@@ -26,19 +27,43 @@ describe('Environment', function() {
       assert.strictEqual(environment.parallelTotalShards, null);
     });
 
-    it('has git commit information', function() {
-      // Test for typeof string here rather than specific values because
-      // these tests check that git info can be read from the local filesystem,
-      // so all of the values will change between commits.
+    it('reads commit information from git', function() {
+      let commitStub = sinon.stub(environment, 'rawCommitData')
+        .returns(`COMMIT_SHA:620804c296827012104931d44b001f20eda9dbeb
+AUTHOR_NAME:Tim Haines
+AUTHOR_EMAIL:timhaines@example.com
+COMMITTER_NAME:Other Tim Haines
+COMMITTER_EMAIL:othertimhaines@example.com
+COMMITTED_DATE:2018-03-07 16:40:12 -0800
+COMMIT_MESSAGE:Sinon stubs are lovely`);
+      let branchStub = sinon.stub(environment, 'rawBranch').returns('test-branch');
       let commit = environment.commitData;
-      assert(typeof commit.branch == 'string');
-      assert(typeof commit.sha == 'string');
-      assert(typeof commit.authorName == 'string');
-      assert(typeof commit.authorEmail == 'string');
-      assert(typeof commit.committerName == 'string');
-      assert(typeof commit.committerEmail == 'string');
-      assert(typeof commit.committedAt == 'string');
-      assert(typeof commit.message == 'string');
+      assert.strictEqual(commit.branch, 'test-branch');
+      assert.strictEqual(commit.sha, '620804c296827012104931d44b001f20eda9dbeb');
+      assert.strictEqual(commit.authorName, 'Tim Haines');
+      assert.strictEqual(commit.authorEmail, 'timhaines@example.com');
+      assert.strictEqual(commit.committerName, 'Other Tim Haines');
+      assert.strictEqual(commit.committerEmail, 'othertimhaines@example.com');
+      assert.strictEqual(commit.committedAt, '2018-03-07 16:40:12 -0800');
+      assert.strictEqual(commit.message, 'Sinon stubs are lovely');
+      commitStub.restore();
+      branchStub.restore();
+    });
+
+    it('commitData returns branch only when git commit cannot be read', function() {
+      let commitStub = sinon.stub(environment, 'rawCommitData').returns('');
+      let branchStub = sinon.stub(environment, 'rawBranch').returns('test-branch');
+      let commit = environment.commitData;
+      assert.strictEqual(commit.branch, 'test-branch');
+      assert.strictEqual(commit.sha, undefined);
+      commitStub.restore();
+      branchStub.restore();
+    });
+
+    it('branch returns null when git branch cannot be read', function() {
+      let branchStub = sinon.stub(environment, 'rawBranch').returns('');
+      assert.strictEqual(environment.branch, null);
+      branchStub.restore();
     });
   });
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -15,15 +15,27 @@ describe('Environment', function() {
     });
 
     it('has the correct properties', function() {
+      assert(typeof environment.branch == 'string');
       assert.strictEqual(environment.ci, null);
       assert.strictEqual(environment.commitSha, null);
-      assert.strictEqual(environment.branch, null);
       assert.strictEqual(environment.targetBranch, null);
       assert.strictEqual(environment.pullRequestNumber, null);
       assert.strictEqual(environment.project, null);
       assert.strictEqual(environment.repo, null); // TODO: Deprecated, remove.
       assert.strictEqual(environment.parallelNonce, null);
       assert.strictEqual(environment.parallelTotalShards, null);
+    });
+
+    it('has git commit information', function() {
+      let commit = environment.commitData;
+      assert(typeof commit.branch == 'string');
+      assert(typeof commit.sha == 'string');
+      assert(typeof commit.authorName == 'string');
+      assert(typeof commit.authorEmail == 'string');
+      assert(typeof commit.committerName == 'string');
+      assert(typeof commit.committerEmail == 'string');
+      assert(typeof commit.committedAt == 'string');
+      assert(typeof commit.message == 'string');
     });
   });
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -27,6 +27,9 @@ describe('Environment', function() {
     });
 
     it('has git commit information', function() {
+      // Test for typeof string here rather than specific values because
+      // these tests check that git info can be read from the local filesystem,
+      // so all of the values will change between commits.
       let commit = environment.commitData;
       assert(typeof commit.branch == 'string');
       assert(typeof commit.sha == 'string');

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -28,10 +28,11 @@ describe('Environment', function() {
     });
 
     it('commitData reads and parses live git commit information', function() {
+      // This checks the real information coming from rawCommitData is in the
+      // expected format and can be correctly parsed.
       // Test for typeof string here rather than specific values because
       // these tests check that git info can be read from the local filesystem,
       // so all of the values will change between commits.
-      // This checks the information coming from rawCommitData is in the right format
       let commit = environment.commitData;
       assert(typeof commit.branch == 'string');
       assert(typeof commit.sha == 'string');
@@ -43,7 +44,7 @@ describe('Environment', function() {
       assert(typeof commit.message == 'string');
     });
 
-    it('commitData correctly parses commit information from git', function() {
+    it('commitData correctly parses rawCommitData', function() {
       let commitStub = sinon.stub(environment, 'rawCommitData')
         .returns(`COMMIT_SHA:620804c296827012104931d44b001f20eda9dbeb
 AUTHOR_NAME:Tim Haines

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -27,7 +27,23 @@ describe('Environment', function() {
       assert.strictEqual(environment.parallelTotalShards, null);
     });
 
-    it('reads commit information from git', function() {
+    it('commitData reads and parses live git commit information', function() {
+      // Test for typeof string here rather than specific values because
+      // these tests check that git info can be read from the local filesystem,
+      // so all of the values will change between commits.
+      // This checks the information coming from rawCommitData is in the right format
+      let commit = environment.commitData;
+      assert(typeof commit.branch == 'string');
+      assert(typeof commit.sha == 'string');
+      assert(typeof commit.authorName == 'string');
+      assert(typeof commit.authorEmail == 'string');
+      assert(typeof commit.committerName == 'string');
+      assert(typeof commit.committerEmail == 'string');
+      assert(typeof commit.committedAt == 'string');
+      assert(typeof commit.message == 'string');
+    });
+
+    it('commitData correctly parses commit information from git', function() {
       let commitStub = sinon.stub(environment, 'rawCommitData')
         .returns(`COMMIT_SHA:620804c296827012104931d44b001f20eda9dbeb
 AUTHOR_NAME:Tim Haines

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -79,14 +79,21 @@ describe('PercyClient', function() {
   describe('createBuild', function() {
     it('returns build data', function(done) {
       let resources = [percyClient.makeResource({resourceUrl: '/foo%20bar', sha: 'fake-sha'})];
+      let commitData = percyClient.environment.commitData;
 
       let expectedRequestData = {
         data: {
           type: 'builds',
           attributes: {
-            branch: percyClient.environment.branch,
+            branch: commitData.branch,
             'target-branch': percyClient.environment.targetBranch,
-            'commit-sha': percyClient.environment.commitSha,
+            'commit-sha': commitData.sha,
+            'commit-committed-at': commitData.committedAt,
+            'commit-author-name': commitData.authorName,
+            'commit-author-email': commitData.authorEmail,
+            'commit-committer-name': commitData.committerName,
+            'commit-committer-email': commitData.committerEmail,
+            'commit-message': commitData.message,
             'pull-request-number': percyClient.environment.pullRequestNumber,
             'parallel-nonce': null,
             'parallel-total-shards': null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,10 +1823,6 @@ insert-module-globals@^7.0.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
-
 invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
@@ -2798,12 +2794,6 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
@@ -2934,12 +2924,6 @@ resolve@^1.1.3, resolve@^1.1.4:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
-  dependencies:
-    path-parse "^1.0.5"
-
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -3046,14 +3030,6 @@ shell-quote@^1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
-
-shelljs@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
 
 sigmund@~1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
 JSONStream@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1201,6 +1207,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -1647,6 +1657,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1951,13 +1965,13 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+isarray@0.0.1, isarray@~0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isarray@~0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2076,6 +2090,10 @@ jssha@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/jssha/-/jssha-2.3.1.tgz#147b2125369035ca4b2f7d210dc539f009b3de9a"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2179,6 +2197,10 @@ listr@^0.12.0:
     stream-to-observable "^0.1.0"
     strip-ansi "^3.0.1"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
@@ -2205,6 +2227,10 @@ log-update@^1.0.2:
   dependencies:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
+
+lolex@^2.2.0, lolex@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
 
 loose-envify@^1.0.0:
   version "1.3.1"
@@ -2355,6 +2381,16 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nise@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.3.0.tgz#7d6d506e64a0e37959495157f30a799c0436df72"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 nock@^9.0.14:
   version "9.0.14"
@@ -2578,6 +2614,12 @@ path-parse@^1.0.5:
 path-platform@~0.11.15:
   version "0.11.15"
   resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 pbkdf2@^3.0.3:
   version "3.0.12"
@@ -2957,6 +2999,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -3016,6 +3062,18 @@ sigmund@~1.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.4.2.tgz#c4c41d4bd346e1d33594daec2d5df0548334fc65"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    diff "^3.1.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^5.1.0"
+    type-detect "^4.0.5"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3183,6 +3241,12 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-observable@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -3224,6 +3288,10 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -3305,6 +3373,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,6 +1809,10 @@ insert-module-globals@^7.0.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
+interpret@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+
 invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
@@ -2752,6 +2756,12 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
@@ -2882,6 +2892,12 @@ resolve@^1.1.3, resolve@^1.1.4:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.1.6:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -2984,6 +3000,14 @@ shell-quote@^1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shelljs@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 sigmund@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This introduces collecting git commit and branch info from the locally run `git` command, if it hasn't already been specified by ENV vars.

The main benefit of this is that the meta-information no longer needs to be collected from GitHub, so source access is no longer required.