### PR TITLE
Support GitLab CI environment variables

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -35,8 +35,18 @@ class Environment {
       return 'buildkite';
     } else if (this._env.HEROKU_TEST_RUN_ID) {
       return 'heroku';
+    } else if (this._env.GITLAB_CI == 'true') {
+      return 'gitlab';
     }
     return null;
+  }
+
+  get ciVersion() {
+    switch (this.ci) {
+      case 'gitlab':
+        return `gitlab/${this._env.CI_SERVER_VERSION}`;
+    }
+    return this.ci;
   }
 
   gitExec(args) {
@@ -134,6 +144,8 @@ class Environment {
       }
       case 'heroku':
         return this._env.HEROKU_TEST_RUN_COMMIT_VERSION;
+      case 'gitlab':
+        return this._env.CI_COMMIT_SHA;
     }
 
     return null;
@@ -176,6 +188,9 @@ class Environment {
         break;
       case 'heroku':
         result = this._env.HEROKU_TEST_RUN_BRANCH;
+        break;
+      case 'gitlab':
+        result = this._env.CI_COMMIT_REF_NAME;
         break;
     }
 
@@ -278,6 +293,8 @@ class Environment {
         return this._env.BUILDKITE_BUILD_ID;
       case 'heroku':
         return this._env.HEROKU_TEST_RUN_ID;
+      case 'gitlab':
+        return this._env.CI_JOB_ID;
     }
     return null;
   }

--- a/src/user-agent.js
+++ b/src/user-agent.js
@@ -16,7 +16,7 @@ class UserAgent {
     let environment = [
       this._client._environmentInfo,
       `node/${this._nodeVersion()}`,
-      this._client.environment.ci,
+      this._client.environment.ciVersion,
     ]
       .filter(el => el != null)
       .join('; ');

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -365,6 +365,32 @@ COMMIT_MESSAGE:Sinon stubs are lovely`);
     });
   });
 
+  context('in GitLab', function() {
+    beforeEach(function() {
+      environment = new Environment({
+        GITLAB_CI: 'true',
+        CI_COMMIT_SHA: 'gitlab-commit-sha',
+        CI_COMMIT_REF_NAME: 'gitlab-branch',
+        CI_JOB_ID: 'gitlab-job-id',
+        CI_SERVER_VERSION: '8.14.3-ee',
+      });
+    });
+
+    context('push build', function() {
+      it('has the correct properties', function() {
+        assert.strictEqual(environment.ci, 'gitlab');
+        assert.strictEqual(environment.commitSha, 'gitlab-commit-sha');
+        assert.strictEqual(environment.targetCommitSha, null);
+        assert.strictEqual(environment.branch, 'gitlab-branch');
+        assert.strictEqual(environment.targetBranch, null);
+        assert.strictEqual(environment.pullRequestNumber, null);
+        assert.strictEqual(environment.project, null);
+        assert.strictEqual(environment.parallelNonce, 'gitlab-job-id');
+        assert.strictEqual(environment.parallelTotalShards, null);
+      });
+    });
+  });
+
   context('in Heroku CI', function() {
     beforeEach(function() {
       environment = new Environment({

--- a/test/user-agent-test.js
+++ b/test/user-agent-test.js
@@ -1,6 +1,7 @@
 let path = require('path');
 let UserAgent = require(path.join(__dirname, '..', 'src', 'user-agent'));
 let PercyClient = require(path.join(__dirname, '..', 'src', 'main'));
+let Environment = require(path.join(__dirname, '..', 'src', 'environment'));
 let assert = require('assert');
 
 import {version} from '../package.json';
@@ -24,6 +25,36 @@ describe('UserAgent', function() {
       it('is correct', function() {
         let regex = new RegExp(
           `Percy/v1 percy-js/${version} ` + `\\(node/${process.version}(; travis)?\\)`,
+        );
+
+        assert(
+          userAgent.toString().match(regex),
+          `"${userAgent.toString()}" user agent does not match ${regex}`,
+        );
+      });
+    });
+  });
+
+  context('with a gitlab version present', function() {
+    let environment;
+
+    beforeEach(function() {
+      environment = new Environment({
+        GITLAB_CI: 'true',
+        CI_SERVER_VERSION: '8.14.3-ee',
+      });
+      percyClient = new PercyClient({environment: environment});
+      userAgent = new UserAgent(percyClient);
+    });
+
+    afterEach(function() {
+      environment = null;
+    });
+
+    describe('userAgent', function() {
+      it('is correct', function() {
+        let regex = new RegExp(
+          `Percy/v1 percy-js/${version} ` + `\\(node/${process.version}; gitlab/8.14.3-ee\\)`,
         );
 
         assert(


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/percy/story/2119/support-gitlab-ci-environment-variables-in-javascript-client)

Add environment variables for GitLab CI, as defined [here](https://docs.gitlab.com/ee/ci/variables/#predefined-variables-environment-variables):


| Variable                        | GitLab | Runner | Description |
|-------------------------------- |--------|--------|-------------|
| **CI_COMMIT_REF_NAME**          | 9.0    | all    | The branch or tag name for which project is built |
| **CI_COMMIT_SHA**               | 9.0    | all    | The commit revision for which project is built |
| **CI_COMMIT_TITLE**             | 10.8   | all    | The title of the commit - the full first line of the message |
| **CI_JOB_ID**                   | 9.0    | all    | The unique id of the current job that GitLab CI uses internally |
| **GITLAB_CI**                   | all    | all    | Mark that job is executed in GitLab CI environment |
| **CI_SERVER_VERSION** | all | all | GitLab version that is used to schedule jobs |
