### PR TITLE
Add a note about Yarn 2FA support

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,7 @@
 1. `git push --tags` (possibly wrong now, improve next time through)
 1. Ensure tests have passed on that tag
 1. [Update the release notes](https://github.com/percy/percy-js/releases) on GitHub
-1. `yarn publish` (leave new version blank)
+1. `yarn publish` (leave new version blank), or use `npm publish` if you have 2FA enabled for npm until [this issue](https://github.com/yarnpkg/yarn/issues/4904) is fixed
 1. [Visit npm](https://www.npmjs.com/package/percy-client) and see the new version is live
 1. Update [percy-web](https://github.com/percy/percy-web) to use the new version
 


### PR DESCRIPTION
Update docs to include alternatives to yarn publish until it supports npm passthrough 2FA tokens.