### PR TITLE
move lint-staged to devDependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
-    "lint-staged": "^7.0.4"
+    "lint-staged": "^7.0.4",
     "mocha": "^2.4.5",
     "nock": "^9.2.5",
     "prettier": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -44,13 +44,11 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
+    "lint-staged": "^7.0.4"
     "mocha": "^2.4.5",
     "nock": "^9.2.5",
     "prettier": "^1.12.1",
     "sinon": "^4.5.0"
-  },
-  "optionalDependencies": {
-    "lint-staged": "^7.0.4"
   },
   "dependencies": {
     "base64-js": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
-    "lint-staged": "^7.0.4",
+    "lint-staged": "^6.1.1",
     "mocha": "^2.4.5",
     "nock": "^9.2.5",
     "prettier": "^1.12.1",


### PR DESCRIPTION
Hello,

lint-staged is currently downloaded by yarn because it's an optional dependency. It should be a devDependency, that way only those who works on this repo will download it :)

Thanks