### PR TITLE
Add SDK client and environment info to user agent

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -62,8 +62,8 @@ class PercyClient {
     });
     this._clientInfo = options.clientInfo;
     this._environmentInfo = options.environmentInfo;
-    this._sdkClientInfo = '(SDK client info not set)';
-    this._sdkEnvironmentInfo = '(SDK environment info not set)';
+    this._sdkClientInfo = null;
+    this._sdkEnvironmentInfo = null;
   }
 
   _headers(headers) {

--- a/src/main.js
+++ b/src/main.js
@@ -60,8 +60,8 @@ class PercyClient {
       maxSockets: 5,
       keepAlive: true,
     });
-    this._clientInfo = options.clientInfo;
-    this._environmentInfo = options.environmentInfo;
+    this._genericClientInfo = options.clientInfo;
+    this._genericEnvironmentInfo = options.environmentInfo;
   }
 
   _headers(headers) {
@@ -261,6 +261,8 @@ class PercyClient {
       },
     };
 
+    this._specificClientInfo = options.clientInfo || 'no client info';
+    this._specificEnvironmentInfo = options.environmentInfo || 'no env info';
     return this._httpPost(`${this.apiUrl}/builds/${buildId}/snapshots/`, data);
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -60,8 +60,10 @@ class PercyClient {
       maxSockets: 5,
       keepAlive: true,
     });
-    this._genericClientInfo = options.clientInfo;
-    this._genericEnvironmentInfo = options.environmentInfo;
+    this._clientInfo = options.clientInfo;
+    this._environmentInfo = options.environmentInfo;
+    this._sdkClientInfo = '(SDK client info not set)';
+    this._sdkEnvironmentInfo = '(SDK environment info not set)';
   }
 
   _headers(headers) {
@@ -261,8 +263,8 @@ class PercyClient {
       },
     };
 
-    this._specificClientInfo = options.clientInfo || 'no client info';
-    this._specificEnvironmentInfo = options.environmentInfo || 'no env info';
+    this._sdkClientInfo = options.clientInfo;
+    this._sdkEnvironmentInfo = options.environmentInfo;
     return this._httpPost(`${this.apiUrl}/builds/${buildId}/snapshots/`, data);
   }
 

--- a/src/user-agent.js
+++ b/src/user-agent.js
@@ -11,16 +11,16 @@ class UserAgent {
   toString() {
     let client = [
       `Percy/${this._apiVersion()}`,
-      this._client._specificClientInfo,
-      this._client._genericClientInfo,
+      this._client._sdkClientInfo,
+      this._client._clientInfo,
       `percy-js/${version}`,
     ]
       .filter(el => el != null)
       .join(' ');
 
     let environment = [
-      this._client._specificEnvironmentInfo,
-      this._client._genericEnvironmentInfo,
+      this._client._sdkEnvironmentInfo,
+      this._client._environmentInfo,
       `node/${this._nodeVersion()}`,
       this._client.environment.ciVersion,
     ]

--- a/src/user-agent.js
+++ b/src/user-agent.js
@@ -9,12 +9,18 @@ class UserAgent {
   }
 
   toString() {
-    let client = [`Percy/${this._apiVersion()}`, this._client._clientInfo, `percy-js/${version}`]
+    let client = [
+      `Percy/${this._apiVersion()}`,
+      this._client._specificClientInfo,
+      this._client._genericClientInfo,
+      `percy-js/${version}`,
+    ]
       .filter(el => el != null)
       .join(' ');
 
     let environment = [
-      this._client._environmentInfo,
+      this._client._specificEnvironmentInfo,
+      this._client._genericEnvironmentInfo,
       `node/${this._nodeVersion()}`,
       this._client.environment.ciVersion,
     ]

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -2,6 +2,7 @@ let path = require('path');
 let assert = require('assert');
 let utils = require(path.join(__dirname, '..', 'src', 'utils'));
 let PercyClient = require(path.join(__dirname, '..', 'src', 'main'));
+let UserAgent = require(path.join(__dirname, '..', 'src', 'user-agent'));
 let nock = require('nock');
 let fs = require('fs');
 
@@ -647,6 +648,8 @@ describe('PercyClient', function() {
         enableJavaScript: true,
         widths: [1000],
         minimumHeight: 100,
+        clientInfo: '@percy/cypress/0.2.0',
+        environmentInfo: 'cypress/3.1.0',
       };
       let resource = percyClient.makeResource({
         resourceUrl: '/foo',
@@ -661,6 +664,14 @@ describe('PercyClient', function() {
           assert.equal(response.statusCode, 201);
           // This is not the actual API response, we just mocked it above.
           assert.deepEqual(response.body, {success: true});
+
+          // Ensure that data from createSnapshot gets through to userAgent
+          const userAgent = new UserAgent(percyClient);
+          assert.deepEqual(
+            userAgent.toString(),
+            'Percy/v1 @percy/cypress/0.2.0 percy-js/3.0.2 (cypress/3.1.0; node/v8.7.0)',
+          );
+
           done();
         })
         .catch(err => {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -667,10 +667,8 @@ describe('PercyClient', function() {
 
           // Ensure that data from createSnapshot gets through to userAgent
           const userAgent = new UserAgent(percyClient);
-          assert.deepEqual(
-            userAgent.toString(),
-            'Percy/v1 @percy/cypress/0.2.0 percy-js/3.0.2 (cypress/3.1.0; node/v8.7.0)',
-          );
+          assert(userAgent.toString().includes('@percy/cypress/0.2.0'));
+          assert(userAgent.toString().includes('cypress/3.1.0'));
 
           done();
         })

--- a/test/user-agent-test.js
+++ b/test/user-agent-test.js
@@ -6,6 +6,8 @@ let assert = require('assert');
 
 import {version} from '../package.json';
 
+// Regex is used to check matching in this file so we can have the tests pass both locally
+// and remotely (when `travis` is included in the environment string)
 describe('UserAgent', function() {
   let userAgent;
   let percyClient;
@@ -109,11 +111,15 @@ describe('UserAgent', function() {
         userAgent = new UserAgent(percyClient);
       });
       it('has the correct client and environment info', function() {
-        const expectedUserAgent =
-          `Percy/v1 ${sdkClientInfo} ${clientInfo} percy-js/${version}` +
-          ` (${sdkEnvironmentInfo}; ${environmentInfo}; node/${process.version})`;
+        let regex = new RegExp(
+          `Percy/v1 ${sdkClientInfo} ${clientInfo} percy-js/${version} ` +
+            `\\(${sdkEnvironmentInfo}; ${environmentInfo}; node/${process.version}(; travis)?\\)`,
+        );
 
-        assert.strictEqual(userAgent.toString(), expectedUserAgent);
+        assert(
+          userAgent.toString().match(regex),
+          `"${userAgent.toString()}" user agent does not match ${regex}`,
+        );
       });
     });
   });

--- a/test/user-agent-test.js
+++ b/test/user-agent-test.js
@@ -91,4 +91,30 @@ describe('UserAgent', function() {
       });
     });
   });
+
+  context('sdkClient and sdkEnvironment info sent from percy-agent', function() {
+    const clientInfo = 'react-percy-storybook/1.0.0';
+    const environmentInfo = 'react/15.6.1';
+    const sdkClientInfo = '@percy/cypress/0.2.0';
+    const sdkEnvironmentInfo = 'cypress/3.1.0';
+
+    describe('userAgent', function() {
+      beforeEach(function() {
+        percyClient = new PercyClient({
+          clientInfo: clientInfo,
+          environmentInfo: environmentInfo,
+        });
+        percyClient._sdkClientInfo = sdkClientInfo;
+        percyClient._sdkEnvironmentInfo = sdkEnvironmentInfo;
+        userAgent = new UserAgent(percyClient);
+      });
+      it('has the correct client and environment info', function() {
+        const expectedUserAgent =
+          `Percy/v1 ${sdkClientInfo} ${clientInfo} percy-js/${version}` +
+          ` (${sdkEnvironmentInfo}; ${environmentInfo}; node/${process.version})`;
+
+        assert.strictEqual(userAgent.toString(), expectedUserAgent);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Previously, all user-agent information was known when a build was created. This allowed us to gather all user agent information in the build creation method and be on our way. But with percy-agent, we don't know anything about the SDK until a `createSnapshot` call is made.

This requires adding additional information to the userAgent string in the middle of a build. To accomplish this, I've added two new properties to `percyClient` -- `_sdkClientInfo` and _`sdkEnvironmentInfo`. These two properties are now concatenated into the userAgent string if present and ignored if not. 

This will allow any sdk using `percy-agent` to pass along information specific to itself, and still have the build-level environment data set.

Percy-agent companion PR: https://github.com/percy/percy-agent/pull/32

See build info of https://percy.io/test/test/builds/1232218  for an example of the new user agent string.