### PR TITLE
Add Appveyor environment variable detection

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ test_script:
   # run tests
   - yarn build
   - yarn test
+  - env
 
 build:
   off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ test_script:
   # run tests
   - yarn build
   - yarn test
-  - env
 
 build:
   off

--- a/src/environment.js
+++ b/src/environment.js
@@ -39,7 +39,10 @@ class Environment {
       return 'gitlab';
     } else if (this._env.TF_BUILD == 'True') {
       return 'azure';
+    } else if (this._env.APPVEYOR == 'True' || this._env.APPVEYOR == 'true') {
+      return 'appveyor';
     }
+
     return null;
   }
 
@@ -150,6 +153,8 @@ class Environment {
         return this._env.CI_COMMIT_SHA;
       case 'azure':
         return this._env.SYSTEM_PULLREQUEST_SOURCECOMMITID || this._env.BUILD_SOURCEVERSION;
+      case 'appveyor':
+        return this._env.APPVEYOR_PULL_REQUEST_HEAD_COMMIT || this._env.APPVEYOR_REPO_COMMIT;
     }
 
     return null;
@@ -199,6 +204,8 @@ class Environment {
       case 'azure':
         result = this._env.SYSTEM_PULLREQUEST_SOURCEBRANCH || this._env.BUILD_SOURCEBRANCHNAME;
         break;
+      case 'appveyor':
+        result = this._env.APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH || this._env.APPVEYOR_REPO_BRANCH;
     }
 
     if (result == '') {
@@ -248,6 +255,8 @@ class Environment {
           : null;
       case 'azure':
         return this._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER || null;
+      case 'appveyor':
+        return this._env.APPVEYOR_PULL_REQUEST_NUMBER || null;
     }
     return null;
   }
@@ -279,6 +288,8 @@ class Environment {
         return this._env.CI_JOB_ID;
       case 'azure':
         return this._env.BUILD_BUILDID;
+      case 'appveyor':
+        return this._env.APPVEYOR_BUILD_ID;
     }
     return null;
   }

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -450,4 +450,42 @@ COMMIT_MESSAGE:Sinon stubs are lovely`);
       });
     });
   });
+
+  context('in Appveyor', function() {
+    beforeEach(function() {
+      environment = new Environment({
+        APPVEYOR: 'True',
+        APPVEYOR_BUILD_ID: 'appveyor-build-id',
+        APPVEYOR_REPO_COMMIT: 'appveyor-commit-sha',
+        APPVEYOR_REPO_BRANCH: 'appveyor-branch',
+      });
+    });
+
+    it('has the correct properties', function() {
+      assert.strictEqual(environment.ci, 'appveyor');
+      assert.strictEqual(environment.commitSha, 'appveyor-commit-sha');
+      assert.strictEqual(environment.targetCommitSha, null);
+      assert.strictEqual(environment.branch, 'appveyor-branch');
+      assert.strictEqual(environment.targetBranch, null);
+      assert.strictEqual(environment.pullRequestNumber, null);
+      assert.strictEqual(environment.parallelNonce, 'appveyor-build-id');
+      assert.strictEqual(environment.parallelTotalShards, null);
+    });
+
+    context('in Pull Request build', function() {
+      beforeEach(function() {
+        environment._env.APPVEYOR_PULL_REQUEST_NUMBER = '512';
+        environment._env.APPVEYOR_PULL_REQUEST_HEAD_COMMIT = 'appveyor-pr-commit-sha';
+        environment._env.APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH = 'appveyor-pr-branch';
+      });
+
+      it('has the correct properties', function() {
+        assert.strictEqual(environment.pullRequestNumber, '512');
+        assert.strictEqual(environment.branch, 'appveyor-pr-branch');
+        assert.strictEqual(environment.targetBranch, null);
+        assert.strictEqual(environment.commitSha, 'appveyor-pr-commit-sha');
+        assert.strictEqual(environment.targetCommitSha, null);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds basic support for appveyor environment detection.  

Appveyor doesn't seem to have an environment variable for reporting total nodes in a parallelized build.