### PR TITLE
Add Jenkins environment detection support

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -83,8 +83,8 @@ class Environment {
   }
 
   // If not running in a git repo, allow undefined for certain commit attributes.
-  parse(text, regex) {
-    return ((text && text.match(regex)) || [])[1];
+  parse(formattedCommitData, regex) {
+    return ((formattedCommitData && formattedCommitData.match(regex)) || [])[1];
   }
 
   get commitData() {
@@ -102,28 +102,28 @@ class Environment {
     };
 
     // Try and get more meta-data from git
-    let output = '';
+    let formattedCommitData = '';
     if (this.commitSha) {
-      output = this.rawCommitData(this.commitSha);
+      formattedCommitData = this.rawCommitData(this.commitSha);
     }
-    if (!output) {
-      output = this.rawCommitData('HEAD');
+    if (!formattedCommitData) {
+      formattedCommitData = this.rawCommitData('HEAD');
     }
-    if (!output) {
+    if (!formattedCommitData) {
       return result;
     }
 
     // If this.commitSha didn't provide a sha, use the one from the commit
     if (!result.sha) {
-      result.sha = this.parse(output, /COMMIT_SHA:(.*)/);
+      result.sha = this.parse(formattedCommitData, /COMMIT_SHA:(.*)/);
     }
 
-    result.message = this.parse(output, /COMMIT_MESSAGE:(.*)/m);
-    result.committedAt = this.parse(output, /COMMITTED_DATE:(.*)/);
-    result.authorName = this.parse(output, /AUTHOR_NAME:(.*)/);
-    result.authorEmail = this.parse(output, /AUTHOR_EMAIL:(.*)/);
-    result.committerName = this.parse(output, /COMMITTER_NAME:(.*)/);
-    result.committerEmail = this.parse(output, /COMMITTER_EMAIL:(.*)/);
+    result.message = this.parse(formattedCommitData, /COMMIT_MESSAGE:(.*)/m);
+    result.committedAt = this.parse(formattedCommitData, /COMMITTED_DATE:(.*)/);
+    result.authorName = this.parse(formattedCommitData, /AUTHOR_NAME:(.*)/);
+    result.authorEmail = this.parse(formattedCommitData, /AUTHOR_EMAIL:(.*)/);
+    result.committerName = this.parse(formattedCommitData, /COMMITTER_NAME:(.*)/);
+    result.committerEmail = this.parse(formattedCommitData, /COMMITTER_EMAIL:(.*)/);
 
     return result;
   }
@@ -133,15 +133,15 @@ class Environment {
       return false;
     }
 
-    let output = this.rawCommitData(commitSha);
+    let formattedCommitData = this.rawCommitData(commitSha);
 
-    if (!output) {
+    if (!formattedCommitData) {
       return false;
     }
 
-    let authorName = this.parse(output, /AUTHOR_NAME:(.*)/);
-    let authorEmail = this.parse(output, /AUTHOR_EMAIL:(.*)/);
-    let message = this.parse(output, /COMMIT_MESSAGE:(.*)/m);
+    let authorName = this.parse(formattedCommitData, /AUTHOR_NAME:(.*)/);
+    let authorEmail = this.parse(formattedCommitData, /AUTHOR_EMAIL:(.*)/);
+    let message = this.parse(formattedCommitData, /COMMIT_MESSAGE:(.*)/m);
 
     if (authorName === 'Jenkins' && authorEmail === 'nobody@nowhere') {
       if (message.substring(0, 13) === 'Merge commit ' && message.substring(55) === ' into HEAD') {
@@ -153,13 +153,13 @@ class Environment {
   }
 
   getSecondToLastCommitSHA() {
-    let output = this.rawCommitData('HEAD^');
+    let formattedCommitData = this.rawCommitData('HEAD^');
 
-    if (!output) {
+    if (!formattedCommitData) {
       return null;
     }
 
-    return this.parse(output, /COMMIT_SHA:(.*)/);
+    return this.parse(formattedCommitData, /COMMIT_SHA:(.*)/);
   }
 
   get commitSha() {

--- a/src/environment.js
+++ b/src/environment.js
@@ -22,7 +22,7 @@ class Environment {
       return 'travis';
     } else if (this._env.JENKINS_URL && this._env.ghprbPullId) {
       // Pull Request Builder plugin.
-      return 'jenkins';
+      return 'jenkins-prb';
     } else if (this._env.CIRCLECI) {
       return 'circle';
     } else if (this._env.CI_NAME && this._env.CI_NAME == 'codeship') {
@@ -131,7 +131,7 @@ class Environment {
     switch (this.ci) {
       case 'travis':
         return this._env.TRAVIS_COMMIT;
-      case 'jenkins':
+      case 'jenkins-prb':
         // Pull Request Builder Plugin OR Git Plugin.
         return this._env.ghprbActualCommit || this._env.GIT_COMMIT;
       case 'circle':
@@ -177,7 +177,7 @@ class Environment {
           result = this._env.TRAVIS_BRANCH;
         }
         break;
-      case 'jenkins':
+      case 'jenkins-prb':
         result = this._env.ghprbSourceBranch;
         break;
       case 'circle':
@@ -235,7 +235,7 @@ class Environment {
     switch (this.ci) {
       case 'travis':
         return this._env.TRAVIS_PULL_REQUEST !== 'false' ? this._env.TRAVIS_PULL_REQUEST : null;
-      case 'jenkins':
+      case 'jenkins-prb':
         return this._env.ghprbPullId;
       case 'circle':
         if (this._env.CI_PULL_REQUESTS && this._env.CI_PULL_REQUESTS !== '') {
@@ -270,7 +270,7 @@ class Environment {
     switch (this.ci) {
       case 'travis':
         return this._env.TRAVIS_BUILD_NUMBER;
-      case 'jenkins':
+      case 'jenkins-prb':
         return this._env.BUILD_NUMBER;
       case 'circle':
         return this._env.CIRCLE_WORKFLOW_WORKSPACE_ID || this._env.CIRCLE_BUILD_NUM;
@@ -305,7 +305,7 @@ class Environment {
           return parseInt(this._env.CI_NODE_TOTAL);
         }
         break;
-      case 'jenkins':
+      case 'jenkins-prb':
         break;
       case 'circle':
         if (this._env.CIRCLE_NODE_TOTAL) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -129,17 +129,19 @@ class Environment {
   }
 
   jenkinsMergeCommitBuild(commitSha) {
-    let output = this.rawCommitData(commitSha);
-    let authorName = this.parse(output, /AUTHOR_NAME:(.*)/);
-    let authorEmail = this.parse(output, /AUTHOR_EMAIL:(.*)/);
-    let message = this.parse(output, /COMMIT_MESSAGE:(.*)/m);
+    if (commitSha) {
+      let output = this.rawCommitData(commitSha);
+      let authorName = this.parse(output, /AUTHOR_NAME:(.*)/);
+      let authorEmail = this.parse(output, /AUTHOR_EMAIL:(.*)/);
+      let message = this.parse(output, /COMMIT_MESSAGE:(.*)/m);
 
-    if (authorName === 'Jenkins' && authorEmail === 'nobody@nowhere') {
-      if (
-        message.substring(0, 13) === 'Merge commit ' &&
-        message.substring(56, 10) === ' into HEAD'
-      ) {
-        return true;
+      if (authorName === 'Jenkins' && authorEmail === 'nobody@nowhere') {
+        if (
+          message.substring(0, 13) === 'Merge commit ' &&
+          message.substring(55) === ' into HEAD'
+        ) {
+          return true;
+        }
       }
     }
 
@@ -273,7 +275,7 @@ class Environment {
       case 'jenkins-prb':
         return this._env.ghprbPullId;
       case 'jenkins':
-        return this._env.CHANGE_ID;
+        return this._env.CHANGE_ID || null;
       case 'circle':
         if (this._env.CI_PULL_REQUESTS && this._env.CI_PULL_REQUESTS !== '') {
           return this._env.CI_PULL_REQUESTS.split('/').slice(-1)[0];

--- a/src/environment.js
+++ b/src/environment.js
@@ -148,7 +148,7 @@ class Environment {
     return false;
   }
 
-  getSecondToLastCommit() {
+  getSecondToLastCommitSHA() {
     let output = this.rawCommitData('HEAD^');
     return this.parse(output, /COMMIT_SHA:(.*)/);
   }
@@ -165,7 +165,7 @@ class Environment {
         return this._env.ghprbActualCommit || this._env.GIT_COMMIT;
       case 'jenkins':
         if (this.jenkinsMergeCommitBuild()) {
-          return this.getSecondToLastCommit();
+          return this.getSecondToLastCommitSHA();
         }
         return this._env.GIT_COMMIT;
       case 'circle':

--- a/src/environment.js
+++ b/src/environment.js
@@ -144,6 +144,7 @@ class Environment {
     let message = this.parse(formattedCommitData, /COMMIT_MESSAGE:(.*)/m);
 
     if (authorName === 'Jenkins' && authorEmail === 'nobody@nowhere') {
+      // Example merge message: Merge commit 'ec4d24c3d22f3c95e34af95c1fda2d462396d885' into HEAD
       if (message.substring(0, 13) === 'Merge commit ' && message.substring(55) === ' into HEAD') {
         return true;
       }

--- a/src/environment.js
+++ b/src/environment.js
@@ -152,7 +152,7 @@ class Environment {
     return false;
   }
 
-  getSecondToLastCommitSHA() {
+  get secondToLastCommitSHA() {
     let formattedCommitData = this.rawCommitData('HEAD^');
 
     if (!formattedCommitData) {
@@ -174,7 +174,7 @@ class Environment {
         return this._env.ghprbActualCommit || this._env.GIT_COMMIT;
       case 'jenkins':
         if (this.jenkinsMergeCommitBuild()) {
-          return this.getSecondToLastCommitSHA();
+          return this.secondToLastCommitSHA;
         }
         return this._env.GIT_COMMIT;
       case 'circle':

--- a/src/environment.js
+++ b/src/environment.js
@@ -129,19 +129,23 @@ class Environment {
   }
 
   jenkinsMergeCommitBuild(commitSha) {
-    if (commitSha) {
-      let output = this.rawCommitData(commitSha);
-      let authorName = this.parse(output, /AUTHOR_NAME:(.*)/);
-      let authorEmail = this.parse(output, /AUTHOR_EMAIL:(.*)/);
-      let message = this.parse(output, /COMMIT_MESSAGE:(.*)/m);
+    if (!commitSha) {
+      return false;
+    }
 
-      if (authorName === 'Jenkins' && authorEmail === 'nobody@nowhere') {
-        if (
-          message.substring(0, 13) === 'Merge commit ' &&
-          message.substring(55) === ' into HEAD'
-        ) {
-          return true;
-        }
+    let output = this.rawCommitData(commitSha);
+
+    if (!output) {
+      return false;
+    }
+
+    let authorName = this.parse(output, /AUTHOR_NAME:(.*)/);
+    let authorEmail = this.parse(output, /AUTHOR_EMAIL:(.*)/);
+    let message = this.parse(output, /COMMIT_MESSAGE:(.*)/m);
+
+    if (authorName === 'Jenkins' && authorEmail === 'nobody@nowhere') {
+      if (message.substring(0, 13) === 'Merge commit ' && message.substring(55) === ' into HEAD') {
+        return true;
       }
     }
 
@@ -150,6 +154,11 @@ class Environment {
 
   getSecondToLastCommitSHA() {
     let output = this.rawCommitData('HEAD^');
+
+    if (!output) {
+      return null;
+    }
+
     return this.parse(output, /COMMIT_SHA:(.*)/);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,4 +98,11 @@ module.exports = {
 
     return resources;
   },
+
+  reverseString(str) {
+    return str
+      .split('')
+      .reverse()
+      .join('');
+  },
 };

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -114,7 +114,7 @@ COMMIT_MESSAGE:A shiny new feature`);
       commitStub.restore();
     });
 
-    it('getSecondToLastCommitSHA returns commit SHA for HEAD^', function() {
+    it('secondToLastCommitSHA returns commit SHA for HEAD^', function() {
       let commitStub = sinon.stub(environment, 'rawCommitData');
       commitStub.withArgs('HEAD^').returns(`COMMIT_SHA:second-to-last-merge-commit-sha
 AUTHOR_NAME:Fred
@@ -124,7 +124,7 @@ COMMITTER_EMAIL:fred@example.com
 COMMITTED_DATE:2018-03-07 16:40:12 -0800
 COMMIT_MESSAGE:A shiny new feature`);
 
-      assert.strictEqual(environment.getSecondToLastCommitSHA(), 'second-to-last-merge-commit-sha');
+      assert.strictEqual(environment.secondToLastCommitSHA, 'second-to-last-merge-commit-sha');
 
       commitStub.restore();
     });

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -236,23 +236,6 @@ COMMIT_MESSAGE:A shiny new feature`);
       assert.strictEqual(environment.parallelTotalShards, null);
     });
 
-    context('in parallel build', function() {
-      beforeEach(function() {
-        // Should be reversed and truncated for parallelNonce
-        // Real BUILD_TAG example: jenkins-Percy-example-percy-puppeteer-PR-34-merge-2
-        environment._env.BUILD_TAG =
-          'XXXb7b7a42f90d49dbe8767c2aebbf7-project-branch-build-number-123';
-      });
-
-      it('has the correct properties', function() {
-        assert.strictEqual(
-          environment.parallelNonce,
-          '321-rebmun-dliub-hcnarb-tcejorp-7fbbea2c7678ebd94d09f24a7b7b',
-        );
-        assert.strictEqual(environment.parallelTotalShards, null);
-      });
-    });
-
     context('in Pull Request build (non-merge)', function() {
       beforeEach(function() {
         environment._env.CHANGE_ID = '111';
@@ -303,6 +286,23 @@ COMMIT_MESSAGE:A shiny new feature`);
 
         commitStub.restore();
         jenkinsMergeCommitBuildStub.restore();
+      });
+    });
+
+    context('in parallel build', function() {
+      beforeEach(function() {
+        // Should be reversed and truncated for parallelNonce
+        // Real BUILD_TAG example: jenkins-Percy-example-percy-puppeteer-PR-34-merge-2
+        environment._env.BUILD_TAG =
+          'XXXb7b7a42f90d49dbe8767c2aebbf7-project-branch-build-number-123';
+      });
+
+      it('has the correct properties', function() {
+        assert.strictEqual(
+          environment.parallelNonce,
+          '321-rebmun-dliub-hcnarb-tcejorp-7fbbea2c7678ebd94d09f24a7b7b',
+        );
+        assert.strictEqual(environment.parallelTotalShards, null);
       });
     });
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -180,7 +180,7 @@ COMMIT_MESSAGE:Sinon stubs are lovely`);
     });
 
     it('has the correct properties', function() {
-      assert.strictEqual(environment.ci, 'jenkins');
+      assert.strictEqual(environment.ci, 'jenkins-prb');
       assert.strictEqual(environment.commitSha, 'jenkins-commit-sha');
       assert.strictEqual(environment.targetCommitSha, null);
       assert.strictEqual(environment.branch, 'jenkins-branch');

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -113,6 +113,21 @@ COMMIT_MESSAGE:A shiny new feature`);
 
       commitStub.restore();
     });
+
+    it('getSecondToLastCommitSHA returns commit SHA for HEAD^', function() {
+      let commitStub = sinon.stub(environment, 'rawCommitData');
+      commitStub.withArgs('HEAD^').returns(`COMMIT_SHA:second-to-last-merge-commit-sha
+AUTHOR_NAME:Fred
+AUTHOR_EMAIL:fred@example.com
+COMMITTER_NAME:Fred
+COMMITTER_EMAIL:fred@example.com
+COMMITTED_DATE:2018-03-07 16:40:12 -0800
+COMMIT_MESSAGE:A shiny new feature`);
+
+      assert.strictEqual(environment.getSecondToLastCommitSHA(), 'second-to-last-merge-commit-sha');
+
+      commitStub.restore();
+    });
   });
 
   context('PERCY_* env vars are set', function() {


### PR DESCRIPTION
This PR adds supports for Jenkins running with the GitHub Branch Source Plugin.

It should correctly handle branch builds, and pull request builds of the merge-commit and non-merge-commit variety.

It also sets up a reversed parallelized BUILD_TAG as the parallel nonce.

[Design doc](https://docs.google.com/document/d/1EupxgdlC3PD8E-my4uzh0kuF65jNXxo0krshbAcVUHs/edit).