### PR TITLE
Update rawCommitData to permit HEAD^

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -73,8 +73,8 @@ class Environment {
   }
 
   rawCommitData(commitSha) {
-    // Make sure commitSha is only alphanumeric characters to prevent command injection.
-    if (commitSha.length > 100 || !commitSha.match(/^[0-9a-zA-Z]+$/)) {
+    // Make sure commitSha is only alphanumeric characters and ^ to prevent command injection.
+    if (commitSha.length > 100 || !commitSha.match(/^[0-9a-zA-Z^]+$/)) {
       return '';
     }
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -125,6 +125,19 @@ COMMIT_MESSAGE:A shiny new feature`);
 
       commitStub.restore();
     });
+
+    it('rawCommitData will return a value for HEAD^', function() {
+      // Reads the real commit data from this repository. The value changes, but should not be ''.
+      var commitData = environment.rawCommitData('HEAD^');
+      assert(typeof commitData == 'string');
+      assert.notEqual(commitData, '');
+    });
+
+    it('rawCommitData will return an empty string for an invalid commitSha', function() {
+      var commitData = environment.rawCommitData('abc;invalid command');
+      assert(typeof commitData == 'string');
+      assert.strictEqual(commitData, '');
+    });
   });
 
   context('PERCY_* env vars are set', function() {


### PR DESCRIPTION
rawCommitData is used to get data from the git command.  We ensure the value passed is sanitized to prevent command injection.  This update allows values that include ^ such as HEAD^ to be requested.