### PR TITLE
Added support for Probo.ci environments

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -45,6 +45,8 @@ class Environment {
       return 'azure';
     } else if (this._env.APPVEYOR == 'True' || this._env.APPVEYOR == 'true') {
       return 'appveyor';
+    } else if (this._env.PROBO_ENVIRONMENT == 'TRUE') {
+      return 'probo';
     }
 
     return null;
@@ -195,6 +197,8 @@ class Environment {
         return this._env.SYSTEM_PULLREQUEST_SOURCECOMMITID || this._env.BUILD_SOURCEVERSION;
       case 'appveyor':
         return this._env.APPVEYOR_PULL_REQUEST_HEAD_COMMIT || this._env.APPVEYOR_REPO_COMMIT;
+      case 'probo':
+        return this._env.COMMIT_REF;
     }
 
     return null;
@@ -249,6 +253,10 @@ class Environment {
         break;
       case 'appveyor':
         result = this._env.APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH || this._env.APPVEYOR_REPO_BRANCH;
+        break;
+      case 'probo':
+        result = this._env.BRANCH_NAME;
+        break;
     }
 
     if (result == '') {
@@ -302,6 +310,11 @@ class Environment {
         return this._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER || null;
       case 'appveyor':
         return this._env.APPVEYOR_PULL_REQUEST_NUMBER || null;
+      case 'probo':
+        if (this._env.PULL_REQUEST_LINK && this._env.PULL_REQUEST_LINK !== '') {
+          return this._env.PULL_REQUEST_LINK.split('/').slice(-1)[0];
+        }
+        break;
     }
     return null;
   }
@@ -340,6 +353,8 @@ class Environment {
         return this._env.BUILD_BUILDID;
       case 'appveyor':
         return this._env.APPVEYOR_BUILD_ID;
+      case 'probo':
+        return this._env.BUILD_ID;
     }
     return null;
   }

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -641,4 +641,27 @@ COMMIT_MESSAGE:A shiny new feature`);
       });
     });
   });
+
+  context('in Probo', function() {
+    beforeEach(function() {
+      environment = new Environment({
+        PROBO_ENVIRONMENT: 'TRUE',
+        BUILD_ID: 'probo-build-id',
+        COMMIT_REF: 'probo-commit-sha',
+        BRANCH_NAME: 'probo-branch',
+        PULL_REQUEST_LINK: 'https://github.com/owner/repo-name/pull/123',
+      });
+    });
+
+    it('has the correct properties', function() {
+      assert.strictEqual(environment.ci, 'probo');
+      assert.strictEqual(environment.commitSha, 'probo-commit-sha');
+      assert.strictEqual(environment.targetCommitSha, null);
+      assert.strictEqual(environment.branch, 'probo-branch');
+      assert.strictEqual(environment.targetBranch, null);
+      assert.strictEqual(environment.parallelNonce, 'probo-build-id');
+      assert.strictEqual(environment.parallelTotalShards, null);
+      assert.strictEqual(environment.pullRequestNumber, '123');
+    });
+  });
 });


### PR DESCRIPTION
Refer to: https://docs.probo.ci/build/environment-variables/

### In this PR
- Added a map from env vars to `Environment` properties
  - `environment.ci = "probo"`
  - `environment.branch = $BRANCH_NAME`
  - `environment.parallelNonce = $BUILD_ID`
  - `environment.commitSha = $COMMIT_REF`
  - `environment.pullRequestNumber` is taken from `$PULL_REQUEST_LINK`
- Added a test to confirm properties are set correctly

### In the mean time
- Anyone running a Probo environment can use the following to get Percy environment variables set without this patch:
  - `export PERCY_TOKEN=[YOUR_PERCY_TOKEN]`
  - `export PERCY_BRANCH=$BRANCH_NAME`
  - `export PERCY_COMMIT=$COMMIT_REF`
  - `export PERCY_PULL_REQUEST=${PULL_REQUEST_LINK##*\/}`
- **Note:** These need to be set in the same Probo "Step" as the Percy command because Probo creates a new shell environment for each step.