### PR TITLE
feat: Check for `CI` env var to catch unknown CI envs

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -49,6 +49,9 @@ class Environment {
       return 'probo';
     } else if (this._env.BITBUCKET_BUILD_NUMBER) {
       return 'bitbucket';
+    } else if (this._env.CI) {
+      // this should always be the last branch
+      return 'CI/unknown';
     }
 
     return null;

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -186,6 +186,32 @@ COMMIT_MESSAGE:A shiny new feature`);
     });
   });
 
+  context('in an unknown CI', function() {
+    beforeEach(function() {
+      environment = new Environment({
+        CI: 'true',
+      });
+    });
+
+    it('returns the right CI value', function() {
+      assert.strictEqual(environment.ci, 'CI/unknown');
+    });
+  });
+
+  context('in a known CI env with CI = true', function() {
+    beforeEach(function() {
+      environment = new Environment({
+        TRAVIS_BUILD_ID: '1234`',
+        CI: 'true',
+      });
+    });
+
+    it('returns the right CI value', function() {
+      assert.notEqual(environment.ci, 'CI/unknown');
+      assert.strictEqual(environment.ci, 'travis');
+    });
+  });
+
   context('in Travis CI', function() {
     beforeEach(function() {
       environment = new Environment({


### PR DESCRIPTION
## What is this

This will let us know if a build is being ran in a CI system that we don't support. Most CI systems will  set the `CI` env var to `true`, so this can give us a better understanding of how many folks are running in CI systems that we're not supporting yet.