### PR TITLE
fix: Use `CI_PIPELINE_ID` over `CI_JOB_ID` for GitLab parallel build

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -367,7 +367,7 @@ class Environment {
       case 'heroku':
         return this._env.HEROKU_TEST_RUN_ID;
       case 'gitlab':
-        return this._env.CI_JOB_ID;
+        return this._env.CI_PIPELINE_ID;
       case 'azure':
         return this._env.BUILD_BUILDID;
       case 'appveyor':

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -539,7 +539,7 @@ COMMIT_MESSAGE:A shiny new feature`);
         GITLAB_CI: 'true',
         CI_COMMIT_SHA: 'gitlab-commit-sha',
         CI_COMMIT_REF_NAME: 'gitlab-branch',
-        CI_JOB_ID: 'gitlab-job-id',
+        CI_PIPELINE_ID: 'gitlab-job-id',
         CI_SERVER_VERSION: '8.14.3-ee',
       });
     });


### PR DESCRIPTION
## What is this? 

`CI_JOB_ID` gives us the id of the current GitLab job, but for parallel builds I think we actually want the _pipelines_ ID, since there will be many _jobs_ running in parallel (and they currently will all get different NONCEs)

- `CI_JOB_ID` - The unique id of the current job that GitLab CI uses internally
- `CI_PIPELINE_ID` - The unique id of the current pipeline that GitLab CI uses internally


## Issue with this approach

From Faun:

> IIRC, using the `CI_JOB_ID` created a unique value per job, and `CI_PIPELINE_ID` created unique values for the entire pipeline. Retries within a pipeline would generate new values for CI_JOB_ID [...]

That means retries with Percy enabled will always fail since the NONCE will match and you can't add snapshots to a finalized build. It also looks like GitLab provides no way of telling if a build has been retried or not. 

I don't think this is a blocker, TravisCI has this same exact limitation (and most other CI systems do too if they're not refreshing the workflow/pipeline/job IDs on retries) 