### PR TITLE
Use dotenv to autoload environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "base64-js": "^1.2.3",
     "bluebird": "^3.5.1",
     "bluebird-retry": "^0.11.0",
+    "dotenv": "^8.1.0",
     "es6-promise-pool": "^2.5.0",
     "jssha": "^2.1.0",
     "regenerator-runtime": "^0.13.1",

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,8 @@ const PromisePool = require('es6-promise-pool');
 const regeneratorRuntime = require('regenerator-runtime'); // eslint-disable-line no-unused-vars
 const fs = require('fs');
 
+require('dotenv').config();
+
 const JSON_API_CONTENT_TYPE = 'application/vnd.api+json';
 const CONCURRENCY = 2;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,6 +1649,11 @@ domain-browser@^1.2.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
+dotenv@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
+  integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
+
 duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
## Purpose

Since this package is responsible for parsing many environment variables, it would be useful to load those variables from a `.env` file automatically.

This also has the effect of autoloading env vars where ever percy-js is imported or required. So in agent, for example, `PERCY_TOKEN` and `PERCY_ENABLE` can both be specified in a `.env` file and be automatically picked up by agent.

## Approach

Uses [dotenv](https://github.com/motdotla/dotenv) and calls the `config` method to load env vars into `process.env`.

I don't think tests are necessary, since that would be testing the functionality of dotenv rather than our usage of it (we don't have default vars, so there is nothing to test about our usage). Manually verified that env vars are automatically picked up.