### PR TITLE
fix: Use `CIRCLE_WORKFLOW_ID` for parallel nonce

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -355,7 +355,7 @@ class Environment {
         }
         break;
       case 'circle':
-        return this._env.CIRCLE_WORKFLOW_WORKSPACE_ID || this._env.CIRCLE_BUILD_NUM;
+        return this._env.CIRCLE_WORKFLOW_ID || this._env.CIRCLE_BUILD_NUM;
       case 'codeship':
         return this._env.CI_BUILD_NUMBER || this._env.CI_BUILD_ID;
       case 'drone':

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -402,7 +402,7 @@ COMMIT_MESSAGE:A shiny new feature`);
 
     context('in Circle 2.0', function() {
       it('has the correct properties', function() {
-        environment._env.CIRCLE_WORKFLOW_WORKSPACE_ID = 'circle-workflow-workspace-id';
+        environment._env.CIRCLE_WORKFLOW_ID = 'circle-workflow-workspace-id';
         assert.strictEqual(environment.parallelNonce, 'circle-workflow-workspace-id');
       });
     });


### PR DESCRIPTION
## What is this?

When rebuilding a workflow on Circle, parallel Percy builds will 409 since the parallel nonce is the same as the previous (already finalized) circle workflow. `CIRCLE_WORKFLOW_ID` will change for each new build as well as rebuilds.

Tested on `@percy/agent` with this new env var and everything looks great. 

Clubhouse with more details too: https://app.clubhouse.io/percy/story/2681/settle-on-the-right-circleci-percy-parallel-nonce-variable