### PR TITLE
feat: Update getBuilds filter param to support array values

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -181,7 +181,15 @@ class PercyClient {
   getBuilds(project, filter) {
     filter = filter || {};
     let queryString = Object.keys(filter)
-      .map(key => 'filter[' + key + ']=' + filter[key])
+      .map(key => {
+        if (Array.isArray(filter[key])) {
+          // If filter value is an array, match Percy API's format expectations of:
+          //   filter[key][]=value1&filter[key][]=value2
+          return filter[key].map(array_value => 'filter[' + key + '][]=' + array_value).join('&');
+        } else {
+          return 'filter[' + key + ']=' + filter[key];
+        }
+      })
       .join('&');
 
     if (queryString.length > 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -185,7 +185,7 @@ class PercyClient {
         if (Array.isArray(filter[key])) {
           // If filter value is an array, match Percy API's format expectations of:
           //   filter[key][]=value1&filter[key][]=value2
-          return filter[key].map(array_value => 'filter[' + key + '][]=' + array_value).join('&');
+          return filter[key].map(array_value => `filter[${key}][]=${array_value}`).join('&');
         } else {
           return 'filter[' + key + ']=' + filter[key];
         }

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -234,6 +234,40 @@ describe('PercyClient', function() {
           });
       });
     });
+
+    describe('filtered by state, branch, and shas', function() {
+      it('returns the response body', function(done) {
+        let responseMock = function(url, requestBody) {
+          // Verify request data.
+          assert.equal(requestBody, '');
+          let responseBody = {foo: 123};
+          return [201, responseBody];
+        };
+
+        nock('https://percy.io')
+          .get(
+            '/api/v1/projects/my_project/builds?filter[branch]=master&filter[state]=finished' +
+              '&filter[shas][]=my_sha&filter[shas][]=my_other_sha',
+          )
+          .reply(201, responseMock);
+
+        let request = percyClient.getBuilds('my_project', {
+          branch: 'master',
+          state: 'finished',
+          shas: ['my_sha', 'my_other_sha'],
+        });
+
+        request
+          .then(response => {
+            assert.equal(response.statusCode, 201);
+            assert.deepEqual(response.body, {foo: 123});
+            done();
+          })
+          .catch(err => {
+            done(err);
+          });
+      });
+    });
   });
 
   describe('makeResource', function() {


### PR DESCRIPTION
Percy's getBuilds API endpoint now supports a few new params: branch, state, and shas.  `shas` is an array of values.

This PR adds support to getBuilds for handling filter params with array values.