### PR TITLE
fix: remove use of deprecated buffer constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "sinon": "^7.2.3"
   },
   "dependencies": {
-    "base64-js": "^1.2.3",
     "bluebird": "^3.5.1",
     "bluebird-retry": "^0.11.0",
     "dotenv": "^8.1.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-const base64 = require('base64-js');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -15,7 +14,7 @@ module.exports = {
   },
 
   base64encode(content) {
-    return base64.fromByteArray(new Buffer(content));
+    return Buffer.from(content).toString('base64');
   },
 
   getMissingResources(response) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,7 +843,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2, base64-js@^1.2.3:
+base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==


### PR DESCRIPTION
## Purpose

A deprecation warning is sometimes logged when errors are not swallowed in `@percy/agent`. The `new Buffer` syntax has been deprecated since Node 10.0.0 in favor of using `Buffer.from` or other similar static methods. `Buffer.from` is available since Node 5.10.0, so will still work in the current Node 8 tests.

I also noticed that we were using a browser-based dependency, `base64-js`, to parse the buffer contents into a base64 string. Node has always had base64 support with buffers, so I'm unsure if this was intentional to support browsers, although browsers do not support the `Buffer` class to begin with. 🤔 

## Approach

- Replaced `new Buffer(content)` with `Buffer.from(content)`
- Replaced `base64-js` with `.toString('base64')`.