### PR TITLE
Add a couple GitHub Action vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "percy-client",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "JavaScript API client library for Percy (https://percy.io).",
   "main": "dist/main.js",
   "scripts": {

--- a/src/environment.js
+++ b/src/environment.js
@@ -49,8 +49,8 @@ class Environment {
       return 'probo';
     } else if (this._env.BITBUCKET_BUILD_NUMBER) {
       return 'bitbucket';
-    } else if (this._env.PERCY_GITHUB_ACTION) {
-      return `github-action/${this._env.PERCY_GITHUB_ACTION}`;
+    } else if (this._env.GITHUB_ACTIONS == 'true') {
+      return 'github';
     } else if (this._env.CI) {
       // this should always be the last branch
       return 'CI/unknown';
@@ -63,6 +63,8 @@ class Environment {
     switch (this.ci) {
       case 'gitlab':
         return `gitlab/${this._env.CI_SERVER_VERSION}`;
+      case 'github':
+        return `github/${this._env.PERCY_GITHUB_ACTION || 'unkown'}`;
     }
     return this.ci;
   }
@@ -208,6 +210,8 @@ class Environment {
         return this._env.COMMIT_REF;
       case 'bitbucket':
         return this._env.BITBUCKET_COMMIT;
+      case 'github':
+        return this._env.GITHUB_SHA;
     }
 
     return null;
@@ -273,6 +277,13 @@ class Environment {
         break;
       case 'bitbucket':
         result = this._env.BITBUCKET_BRANCH;
+        break;
+      case 'github':
+        if (this._env.GITHUB_REF && this._env.GITHUB_REF.match(/^refs\//)) {
+          result = this._env.GITHUB_REF.replace(/^refs\/\w+?\//, '');
+        } else {
+          result = this._env.GITHUB_REF;
+        }
         break;
     }
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -215,18 +215,26 @@ COMMIT_MESSAGE:A shiny new feature`);
     });
   });
 
-  // Most of the env vars are set within the GitHub action
-  // Which are tested in that repo. This will test to verify
-  // the user agent is properly passed through
   context('in GitHub Actions', function() {
     beforeEach(function() {
       environment = new Environment({
-        PERCY_GITHUB_ACTION: 'exec-action/0.1.0',
+        PERCY_GITHUB_ACTION: 'test-action/0.1.0',
+        GITHUB_ACTIONS: 'true',
+        GITHUB_SHA: 'github-commit-sha',
+        GITHUB_REF: 'refs/head/github/branch',
       });
     });
 
     it('has the correct properties', function() {
-      assert.strictEqual(environment.ci, 'github-action/exec-action/0.1.0');
+      assert.strictEqual(environment.ci, 'github');
+      assert.strictEqual(environment.ciVersion, 'github/test-action/0.1.0');
+      assert.strictEqual(environment.commitSha, 'github-commit-sha');
+      assert.strictEqual(environment.targetCommitSha, null);
+      assert.strictEqual(environment.branch, 'github/branch');
+      assert.strictEqual(environment.targetBranch, null);
+      assert.strictEqual(environment.pullRequestNumber, null);
+      assert.strictEqual(environment.parallelNonce, null);
+      assert.strictEqual(environment.parallelTotalShards, null);
     });
   });
 


### PR DESCRIPTION
## Purpose

Since it seems we'll have more than just a couple of GitHub actions, handling commit and branch variables here will reduce a little bit of boilerplate in the action's code.

**The actions are still necessary to get a PR number**

## Approach

Moved the versioning of the CI string into the appropriate getter so that the CI string can be used in switch statements for the commit sha and branch getters.

GitHub's branch variable is a ref name, so the `refs/<ref>` string is removed with a regular expression