### PR TITLE
Add retries on ECONNRESET

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -118,7 +118,13 @@ class PercyClient {
       max_tries: 5,
       throw_original: true,
       predicate: function(err) {
-        return err.statusCode >= 500 && err.statusCode < 600;
+        if (err.statusCode) {
+          return err.statusCode >= 500 && err.statusCode < 600;
+        }
+        if (err.error && !!err.error.code) {
+          return err.error.code == 'ECONNRESET';
+        }
+        return false;
       },
     });
   }

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 
 require('dotenv').config();
 
+const RETRY_ERROR_CODES = ['ECONNRESET', 'ECONNREFUSED', 'EPIPE', 'EHOSTUNREACH', 'EAI_AGAIN'];
 const JSON_API_CONTENT_TYPE = 'application/vnd.api+json';
 const CONCURRENCY = 2;
 
@@ -18,7 +19,7 @@ function retryPredicate(err) {
   if (err.statusCode) {
     return err.statusCode >= 500 && err.statusCode < 600;
   } else if (err.error && !!err.error.code) {
-    return err.error.code === 'ECONNRESET';
+    return RETRY_ERROR_CODES.includes(err.error.code);
   } else {
     return false;
   }

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -55,17 +55,19 @@ describe('PercyClient', function() {
       mock.done();
     });
 
-    it('retries on ECONNRESET', async () => {
-      let mock = nock('https://localhost')
-        .get('/foo')
-        .replyWithError({code: 'ECONNRESET'})
-        .get('/foo')
-        .reply(201, {success: true});
+    ['ECONNRESET', 'ECONNREFUSED', 'EPIPE', 'EHOSTUNREACH', 'EAI_AGAIN'].forEach(code => {
+      it(`retries on ${code}`, async () => {
+        let mock = nock('https://localhost')
+          .get('/foo')
+          .replyWithError({code})
+          .get('/foo')
+          .reply(201, {success: true});
 
-      let response = await percyClient._httpGet('https://localhost/foo');
-      assert.equal(response.statusCode, 201);
-      assert.deepEqual(response.body, {success: true});
-      mock.done();
+        let response = await percyClient._httpGet('https://localhost/foo');
+        assert.equal(response.statusCode, 201);
+        assert.deepEqual(response.body, {success: true});
+        mock.done();
+      });
     });
   });
 
@@ -109,17 +111,19 @@ describe('PercyClient', function() {
       mock.done();
     });
 
-    it('retries on ECONNRESET', async () => {
-      let mock = nock('https://localhost')
-        .post('/foo')
-        .replyWithError({code: 'ECONNRESET'})
-        .post('/foo')
-        .reply(201, {success: true});
+    ['ECONNRESET', 'ECONNREFUSED', 'EPIPE', 'EHOSTUNREACH', 'EAI_AGAIN'].forEach(code => {
+      it(`retries on ${code}`, async () => {
+        let mock = nock('https://localhost')
+          .post('/foo')
+          .replyWithError({code})
+          .post('/foo')
+          .reply(201, {success: true});
 
-      let response = await percyClient._httpPost('https://localhost/foo', {foo: 123});
-      assert.equal(response.statusCode, 201);
-      assert.deepEqual(response.body, {success: true});
-      mock.done();
+        let response = await percyClient._httpPost('https://localhost/foo', {foo: 123});
+        assert.equal(response.statusCode, 201);
+        assert.deepEqual(response.body, {success: true});
+        mock.done();
+      });
     });
   });
 


### PR DESCRIPTION
Have added retries to _httpPost when ECONNRESET is encountered.

Optional Todos:
- [x] Add to _httpGet as well as _httpPost.
- [x] We may also want to retry on these: ECONNREFUSED EPIPE EHOSTUNREACH EAI_AGAIN
- [ ] Not certain of the value, but we may also want to check the error is a StatusCodeError for the statuscode retries, and a RequestError for ECONNRESET and friends.