### PR TITLE
Fix Netlify branch name

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -289,7 +289,7 @@ class Environment {
         }
         break;
       case 'netlify':
-        result = this._env.BRANCH;
+        result = this._env.HEAD;
         break;
     }
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -771,7 +771,7 @@ COMMIT_MESSAGE:A shiny new feature`);
       environment = new Environment({
         NETLIFY: 'true',
         COMMIT_REF: 'netlify-commit-sha',
-        BRANCH: 'netlify-branch',
+        HEAD: 'netlify-branch',
         PULL_REQUEST: 'true',
         REVIEW_ID: '123',
       });


### PR DESCRIPTION
`BRANCH` will return `ref/<pr>/head`

`HEAD` returns the branch name from git
