### PR TITLE
✨ Add support for Semaphore 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "percy-client",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "JavaScript API client library for Percy (https://percy.io).",
   "main": "dist/main.js",
   "scripts": {

--- a/src/environment.js
+++ b/src/environment.js
@@ -63,10 +63,12 @@ class Environment {
 
   get ciVersion() {
     switch (this.ci) {
-      case 'gitlab':
-        return `gitlab/${this._env.CI_SERVER_VERSION}`;
       case 'github':
         return `github/${this._env.PERCY_GITHUB_ACTION || 'unknown'}`;
+      case 'gitlab':
+        return `gitlab/${this._env.CI_SERVER_VERSION}`;
+      case 'semaphore':
+        return this._env.SEMAPHORE_GIT_SHA ? 'semaphore/2.0' : 'semaphore';
     }
     return this.ci;
   }
@@ -194,7 +196,7 @@ class Environment {
       case 'drone':
         return this._env.DRONE_COMMIT;
       case 'semaphore':
-        return this._env.REVISION;
+        return this._env.REVISION || this._env.SEMAPHORE_GIT_PR_SHA || this._env.SEMAPHORE_GIT_SHA;
       case 'buildkite': {
         let commitSha = this._env.BUILDKITE_COMMIT;
         // Buildkite mixes SHAs and non-SHAs in BUILDKITE_COMMIT, so we return null if non-SHA.
@@ -258,7 +260,10 @@ class Environment {
         result = this._env.DRONE_BRANCH;
         break;
       case 'semaphore':
-        result = this._env.BRANCH_NAME;
+        result =
+          this._env.BRANCH_NAME ||
+          this._env.SEMAPHORE_GIT_PR_BRANCH ||
+          this._env.SEMAPHORE_GIT_BRANCH;
         break;
       case 'buildkite':
         result = this._env.BUILDKITE_BRANCH;
@@ -335,7 +340,7 @@ class Environment {
       case 'drone':
         return this._env.CI_PULL_REQUEST;
       case 'semaphore':
-        return this._env.PULL_REQUEST_NUMBER;
+        return this._env.PULL_REQUEST_NUMBER || this._env.SEMAPHORE_GIT_PR_NUMBER || null;
       case 'buildkite':
         return this._env.BUILDKITE_PULL_REQUEST !== 'false'
           ? this._env.BUILDKITE_PULL_REQUEST
@@ -385,7 +390,10 @@ class Environment {
       case 'drone':
         return this._env.DRONE_BUILD_NUMBER;
       case 'semaphore':
-        return `${this._env.SEMAPHORE_BRANCH_ID}/${this._env.SEMAPHORE_BUILD_NUMBER}`;
+        return (
+          this._env.SEMAPHORE_WORKFLOW_ID ||
+          `${this._env.SEMAPHORE_BRANCH_ID}/${this._env.SEMAPHORE_BUILD_NUMBER}`
+        );
       case 'buildkite':
         return this._env.BUILDKITE_BUILD_ID;
       case 'heroku':

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -499,6 +499,7 @@ COMMIT_MESSAGE:A shiny new feature`);
 
     it('has the correct properties', function() {
       assert.strictEqual(environment.ci, 'semaphore');
+      assert.strictEqual(environment.ciVersion, 'semaphore');
       assert.strictEqual(environment.commitSha, 'semaphore-commit-sha');
       assert.strictEqual(environment.targetCommitSha, null);
       assert.strictEqual(environment.branch, 'semaphore-branch');
@@ -507,6 +508,51 @@ COMMIT_MESSAGE:A shiny new feature`);
       let expected_nonce = 'semaphore-branch-id/semaphore-build-number';
       assert.strictEqual(environment.parallelNonce, expected_nonce);
       assert.strictEqual(environment.parallelTotalShards, 2);
+    });
+
+    describe('Semaphore 2.0', () => {
+      beforeEach(() => {
+        environment = new Environment({
+          SEMAPHORE: 'true',
+          SEMAPHORE_GIT_SHA: 'semaphore-2-sha',
+          SEMAPHORE_GIT_BRANCH: 'semaphore-2-branch',
+          SEMAPHORE_WORKFLOW_ID: 'semaphore-2-workflow-id',
+        });
+      });
+
+      it('has the correct properties', () => {
+        assert.strictEqual(environment.ci, 'semaphore');
+        assert.strictEqual(environment.ciVersion, 'semaphore/2.0');
+        assert.strictEqual(environment.commitSha, 'semaphore-2-sha');
+        assert.strictEqual(environment.branch, 'semaphore-2-branch');
+        assert.strictEqual(environment.targetCommitSha, null);
+        assert.strictEqual(environment.targetBranch, null);
+        assert.strictEqual(environment.pullRequestNumber, null);
+        assert.strictEqual(environment.parallelNonce, 'semaphore-2-workflow-id');
+        assert.strictEqual(environment.parallelTotalShards, null);
+      });
+
+      it('has the correct properties for PR builds', () => {
+        environment = new Environment({
+          SEMAPHORE: 'true',
+          SEMAPHORE_GIT_SHA: 'semaphore-2-sha',
+          SEMAPHORE_GIT_PR_SHA: 'semaphore-2-pr-sha',
+          SEMAPHORE_GIT_BRANCH: 'semaphore-2-branch',
+          SEMAPHORE_GIT_PR_BRANCH: 'semaphore-2-pr-branch',
+          SEMAPHORE_GIT_PR_NUMBER: '50',
+          SEMAPHORE_WORKFLOW_ID: 'semaphore-2-workflow-id',
+        });
+
+        assert.strictEqual(environment.ci, 'semaphore');
+        assert.strictEqual(environment.ciVersion, 'semaphore/2.0');
+        assert.strictEqual(environment.commitSha, 'semaphore-2-pr-sha');
+        assert.strictEqual(environment.branch, 'semaphore-2-pr-branch');
+        assert.strictEqual(environment.targetCommitSha, null);
+        assert.strictEqual(environment.targetBranch, null);
+        assert.strictEqual(environment.pullRequestNumber, '50');
+        assert.strictEqual(environment.parallelNonce, 'semaphore-2-workflow-id');
+        assert.strictEqual(environment.parallelTotalShards, null);
+      });
     });
   });
 


### PR DESCRIPTION
## Purpose

Semaphore 2.0 was released [in 2018](https://semaphoreci.com/blog/2018/11/06/semaphore-2-0-launched.html) but we only support Semaphore 1.0

Closes #172 

## Approach

When Semaphore is detected, fallback to 2.0 environment variables when 1.0 variables do not exist. The CI version will be reported as `semaphore/2.0` when the environment variable `SEMAPHORE_GIT_SHA` is found, which should only exist in 2.0.