### PR TITLE
✨ Add dotenv file hierarchy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "percy-client",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "JavaScript API client library for Percy (https://percy.io).",
   "main": "dist/main.js",
   "scripts": {

--- a/src/dotenv.js
+++ b/src/dotenv.js
@@ -3,7 +3,10 @@ const dotenv = require('dotenv');
 // mimic dotenv-rails file hierarchy
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 export function config() {
-  let {NODE_ENV: env} = process.env;
+  let {NODE_ENV: env, PERCY_DISABLE_DOTENV: disable} = process.env;
+
+  // don't load dotenv files when disabled
+  if (disable) return;
 
   let paths = [
     env && `.env.${env}.local`,

--- a/src/dotenv.js
+++ b/src/dotenv.js
@@ -1,0 +1,19 @@
+const dotenv = require('dotenv');
+
+// mimic dotenv-rails file hierarchy
+// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+export function config() {
+  let {NODE_ENV: env} = process.env;
+
+  let paths = [
+    env && `.env.${env}.local`,
+    // .env.local is not loaded in test environments
+    env === 'test' ? null : '.env.local',
+    env && `.env.${env}`,
+    '.env',
+  ].filter(Boolean);
+
+  for (let path of paths) {
+    dotenv.config({path});
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ const PromisePool = require('es6-promise-pool');
 const regeneratorRuntime = require('regenerator-runtime'); // eslint-disable-line no-unused-vars
 const fs = require('fs');
 
-require('dotenv').config();
+require('./dotenv').config();
 
 const RETRY_ERROR_CODES = ['ECONNRESET', 'ECONNREFUSED', 'EPIPE', 'EHOSTUNREACH', 'EAI_AGAIN'];
 const JSON_API_CONTENT_TYPE = 'application/vnd.api+json';


### PR DESCRIPTION
## Purpose

As discovered in #199 the Node [dotenv](https://github.com/motdotla/dotenv) package does not support dotenv file hierarchy out-of-the-box like [dotenv-rails](https://github.com/bkeepers/dotenv) does. Since test commands are run as a child process of the percy command, the `.env` file has already been loaded into the environment via dotenv and will not be overridden by dotenv-rails.

## Approach

The dotenv-rails readme [outlines the order of priority](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use) for various supported files. Since dotenv will only set env vars that have not been previously set, we can load the files in priority order to mimic dotenv-rails hierarchy.

In addition to properly setting variables as expected to be set by dotenv-rails, this also makes it so various `PERCY_*` environment variables can be set in environment specific dotenv files as well.

**The `NODE_ENV` environment variable must be set for environment specific dotenv files.** For example, `NODE_ENV=production` will load `.env.production.local`, `.env.local`, `.env.production`, and `.env` files in that order.

### Questions

As mentioned in #199, we might be wary of continuously adding support for different dotenv language behaviors. I personally like dotenv-rails approach and think it's fine to add this support so we can capture `PERCY_*` variables defined in those files. As for other languages, what are their approaches (if any) and should we include a way to disable loading `.env` files completely in this library?
