### PR TITLE
Add new Azure DevOps PullRequestNumber env var

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -348,8 +348,11 @@ class Environment {
       case 'gitlab':
         return this._env.CI_MERGE_REQUEST_IID || null;
       case 'azure':
-        return this._env.SYSTEM_PULLREQUEST_PULLREQUESTID
-          || this._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER || null;
+        return (
+          this._env.SYSTEM_PULLREQUEST_PULLREQUESTID ||
+          this._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER ||
+          null
+        );
       case 'appveyor':
         return this._env.APPVEYOR_PULL_REQUEST_NUMBER || null;
       case 'probo':

--- a/src/environment.js
+++ b/src/environment.js
@@ -348,7 +348,8 @@ class Environment {
       case 'gitlab':
         return this._env.CI_MERGE_REQUEST_IID || null;
       case 'azure':
-        return this._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER || null;
+        return this._env.SYSTEM_PULLREQUEST_PULLREQUESTID
+          || this._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER || null;
       case 'appveyor':
         return this._env.APPVEYOR_PULL_REQUEST_NUMBER || null;
       case 'probo':

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -700,19 +700,37 @@ COMMIT_MESSAGE:A shiny new feature`);
     });
 
     context('in Pull Request build', function() {
-      beforeEach(function() {
-        environment._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = '512';
-        environment._env.SYSTEM_PULLREQUEST_SOURCECOMMITID = 'azure-pr-commit-sha';
-        environment._env.SYSTEM_PULLREQUEST_SOURCEBRANCH = 'azure-pr-branch';
-      });
+      context('in build triggered by Git'), function() {
+        beforeEach(function() {
+          environment._env.SYSTEM_PULLREQUEST_PULLREQUESTID = '512';
+          environment._env.SYSTEM_PULLREQUEST_SOURCECOMMITID = 'azure-pr-commit-sha';
+          environment._env.SYSTEM_PULLREQUEST_SOURCEBRANCH = 'azure-pr-branch';
+        });
 
-      it('has the correct properties', function() {
-        assert.strictEqual(environment.pullRequestNumber, '512');
-        assert.strictEqual(environment.branch, 'azure-pr-branch');
-        assert.strictEqual(environment.targetBranch, null);
-        assert.strictEqual(environment.commitSha, 'azure-pr-commit-sha');
-        assert.strictEqual(environment.targetCommitSha, null);
-      });
+        it('has the correct properties', function() {
+          assert.strictEqual(environment.pullRequestNumber, '512');
+          assert.strictEqual(environment.branch, 'azure-pr-branch');
+          assert.strictEqual(environment.targetBranch, null);
+          assert.strictEqual(environment.commitSha, 'azure-pr-commit-sha');
+          assert.strictEqual(environment.targetCommitSha, null);
+        });
+      };
+
+      context('in build triggered by GitHub'), function() {
+        beforeEach(function() {
+          environment._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = '512';
+          environment._env.SYSTEM_PULLREQUEST_SOURCECOMMITID = 'azure-pr-commit-sha';
+          environment._env.SYSTEM_PULLREQUEST_SOURCEBRANCH = 'azure-pr-branch';
+        });
+
+        it('has the correct properties', function() {
+          assert.strictEqual(environment.pullRequestNumber, '512');
+          assert.strictEqual(environment.branch, 'azure-pr-branch');
+          assert.strictEqual(environment.targetBranch, null);
+          assert.strictEqual(environment.commitSha, 'azure-pr-commit-sha');
+          assert.strictEqual(environment.targetCommitSha, null);
+        });
+      };
     });
   });
 

--- a/test/environment-test.js
+++ b/test/environment-test.js
@@ -699,8 +699,8 @@ COMMIT_MESSAGE:A shiny new feature`);
       });
     });
 
-    context('in Pull Request build', function() {
-      context('in build triggered by Git'), function() {
+    describe('Pull Request build', function() {
+      context('in build triggered by Git', function() {
         beforeEach(function() {
           environment._env.SYSTEM_PULLREQUEST_PULLREQUESTID = '512';
           environment._env.SYSTEM_PULLREQUEST_SOURCECOMMITID = 'azure-pr-commit-sha';
@@ -714,11 +714,12 @@ COMMIT_MESSAGE:A shiny new feature`);
           assert.strictEqual(environment.commitSha, 'azure-pr-commit-sha');
           assert.strictEqual(environment.targetCommitSha, null);
         });
-      };
+      });
 
-      context('in build triggered by GitHub'), function() {
+      context('in build triggered by GitHub', function() {
         beforeEach(function() {
-          environment._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = '512';
+          environment._env.SYSTEM_PULLREQUEST_PULLREQUESTID = '512';
+          environment._env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER = '524';
           environment._env.SYSTEM_PULLREQUEST_SOURCECOMMITID = 'azure-pr-commit-sha';
           environment._env.SYSTEM_PULLREQUEST_SOURCEBRANCH = 'azure-pr-branch';
         });
@@ -730,7 +731,7 @@ COMMIT_MESSAGE:A shiny new feature`);
           assert.strictEqual(environment.commitSha, 'azure-pr-commit-sha');
           assert.strictEqual(environment.targetCommitSha, null);
         });
-      };
+      });
     });
   });
 


### PR DESCRIPTION
Add support for Azure DevOps change in pull request number environment variable
https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services

> **System.PullRequest.PullRequestId**
> 
> The ID of the pull request that caused this build. For example: 17. (This variable is initialized only if the build ran because of a Git PR affected by a branch policy).


> **System.PullRequest.PullRequestNumber**
> 
> The number of the pull request that caused this build. This variable  is populated for pull requests from GitHub which have a different pull  request ID and pull request number. This variable is only available in a  YAML pipeline if the PR is a affected by a branch policy.
